### PR TITLE
feat: increase code coverage to 100% for Credfeto.Notification.Bot.Shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Added unit test project for Credfeto.Notification.Bot.Server achieving 100% code coverage
 - Tests for Credfeto.Notification.Bot.Twitch.DataTypes assembly - Streamer, Viewer, TwitchUser, and mapper types
 - Increased code coverage for Credfeto.Notification.Bot.Twitch to 100%
+- Tests to increase code coverage to 100% for Credfeto.Notification.Bot.Shared
 ### Fixed
 ### Changed
 - Dependencies - Updated Credfeto.Enumeration to 1.2.144.1906

--- a/src/Credfeto.Notification.Bot.Shared.Tests/DependencyInjectionTests.cs
+++ b/src/Credfeto.Notification.Bot.Shared.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,22 @@
+using FunFair.Test.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Credfeto.Notification.Bot.Shared.Tests;
+
+public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
+{
+    public DependencyInjectionTests(ITestOutputHelper output)
+        : base(output: output, dependencyInjectionRegistration: Configure) { }
+
+    private static IServiceCollection Configure(IServiceCollection services)
+    {
+        return services.AddResources();
+    }
+
+    [Fact]
+    public void MessageChannelMustBeRegistered()
+    {
+        this.RequireService<IMessageChannel<string>>();
+    }
+}

--- a/src/Credfeto.Notification.Bot.Shared.Tests/Services/MessageChannelTests.cs
+++ b/src/Credfeto.Notification.Bot.Shared.Tests/Services/MessageChannelTests.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Notification.Bot.Shared.Services;
@@ -27,6 +28,25 @@ public sealed class MessageChannelTests : TestBase
         {
             string receivedMessage = await this._messageChannel.ReceiveAsync(cts.Token);
             Assert.Equal(expected: message, actual: receivedMessage);
+        }
+    }
+
+    [Fact]
+    public async Task PublishedMessageCanBeReceivedViaReadAllAsync()
+    {
+        const string message = "Hello World";
+
+        await this._messageChannel.PublishAsync(message: message, cancellationToken: this.CancellationToken());
+
+        IAsyncEnumerator<string> enumerator = this
+            ._messageChannel.ReadAllAsync(this.CancellationToken())
+            .GetAsyncEnumerator(this.CancellationToken());
+
+        await using (enumerator)
+        {
+            bool hasNext = await enumerator.MoveNextAsync();
+            Assert.True(condition: hasNext, userMessage: "Expected a message to be available in the channel");
+            Assert.Equal(expected: message, actual: enumerator.Current);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `DependencyInjectionTests` to verify `ResourceSetup.AddResources` registers `IMessageChannel<T>` correctly
- Add test for `MessageChannel<T>.ReadAllAsync` to complete coverage

Closes #231

## Test plan

- [ ] `DependencyInjectionTests.MessageChannelMustBeRegistered` passes
- [ ] `MessageChannelTests.PublishedMessageCanBeReceivedViaReadAllAsync` passes
- [ ] Coverage for `Credfeto.Notification.Bot.Shared` reaches 100% line and method coverage