### PR TITLE
fix: increment _version after unknown Twitch streamer is removed so the next poll refreshes the channel list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- Increment version after removing unknown Twitch streamer so the next poll refreshes the channel list
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Notification.Bot.Twitch.Tests/Services/TwitchStreamStatusTests.cs
+++ b/src/Credfeto.Notification.Bot.Twitch.Tests/Services/TwitchStreamStatusTests.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading.Tasks;
-using Credfeto.Notification.Bot.Mocks;
-using Credfeto.Notification.Bot.Twitch.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Credfeto.Notification.Bot.Twitch.DataTypes;
 using Credfeto.Notification.Bot.Twitch.Services;
 using FunFair.Test.Common;
 using Mediator;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -12,20 +12,19 @@ namespace Credfeto.Notification.Bot.Twitch.Tests.Services;
 
 public sealed class TwitchStreamStatusTests : LoggingTestBase
 {
+    private readonly ILiveStreamMonitor _liveStreamMonitor;
     private readonly TwitchStreamStatus _twitchStreamStatus;
 
     public TwitchStreamStatusTests(ITestOutputHelper output)
         : base(output)
     {
-        IOptions<TwitchBotOptions> options = GetSubstitute<IOptions<TwitchBotOptions>>();
-        options.Value.Returns(
-            new TwitchBotOptions { Authentication = MockReferenceData.TwitchAuthentication, ChatCommands = [] }
-        );
+        this._liveStreamMonitor = GetSubstitute<ILiveStreamMonitor>();
+        this._liveStreamMonitor.UpdateLiveStreamersAsync().Returns(Task.CompletedTask);
 
         IMediator mediator = GetSubstitute<IMediator>();
 
         this._twitchStreamStatus = new TwitchStreamStatus(
-            options: options,
+            liveStreamMonitor: this._liveStreamMonitor,
             mediator: mediator,
             logger: this.GetTypedLogger<TwitchStreamStatus>()
         );
@@ -41,5 +40,32 @@ public sealed class TwitchStreamStatusTests : LoggingTestBase
     public Task UpdateAsyncWithNoChannelsShouldReturnImmediately()
     {
         return this._twitchStreamStatus.UpdateAsync();
+    }
+
+    [Fact]
+    public async Task UpdateAsyncShouldRefreshChannelListAfterUnknownStreamerIsRemoved()
+    {
+        Streamer streamer1 = Streamer.FromString("teststreamer1");
+        Streamer streamer2 = Streamer.FromString("teststreamer2");
+
+        string exceptionMessage = $"No channel with the name \"{streamer1.Value}\" could be found.";
+
+        this._liveStreamMonitor.UpdateLiveStreamersAsync()
+            .Returns(
+                Task.CompletedTask,
+                Task.CompletedTask,
+                Task.FromException(new InvalidOperationException(exceptionMessage)),
+                Task.CompletedTask
+            );
+
+        await this._twitchStreamStatus.EnableAsync(streamer1);
+        await this._twitchStreamStatus.EnableAsync(streamer2);
+
+        await this._twitchStreamStatus.UpdateAsync();
+
+        await this._twitchStreamStatus.UpdateAsync();
+
+        this._liveStreamMonitor.Received(1)
+            .SetChannelsByName(Arg.Is<List<string>>(l => l.Count == 1 && l.Contains(streamer2.Value)));
     }
 }

--- a/src/Credfeto.Notification.Bot.Twitch/Services/ILiveStreamMonitor.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/ILiveStreamMonitor.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TwitchLib.Api.Services.Events.LiveStreamMonitor;
+
+namespace Credfeto.Notification.Bot.Twitch.Services;
+
+public interface ILiveStreamMonitor
+{
+    event EventHandler<OnStreamOnlineArgs>? OnStreamOnline;
+    event EventHandler<OnStreamOfflineArgs>? OnStreamOffline;
+    void SetChannelsByName(List<string> channelsToMonitor);
+    Task UpdateLiveStreamersAsync();
+}

--- a/src/Credfeto.Notification.Bot.Twitch/Services/LiveStreamMonitorAdapter.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/LiveStreamMonitorAdapter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Credfeto.Notification.Bot.Twitch.Configuration;
+using Credfeto.Notification.Bot.Twitch.Extensions;
+using Microsoft.Extensions.Options;
+using TwitchLib.Api.Services;
+using TwitchLib.Api.Services.Events.LiveStreamMonitor;
+
+namespace Credfeto.Notification.Bot.Twitch.Services;
+
+public sealed class LiveStreamMonitorAdapter : ILiveStreamMonitor
+{
+    private readonly LiveStreamMonitorService _service;
+
+    public LiveStreamMonitorAdapter(IOptions<TwitchBotOptions> options)
+    {
+        this._service = new(options.Value.ConfigureTwitchApi());
+    }
+
+    public event EventHandler<OnStreamOnlineArgs>? OnStreamOnline
+    {
+        add => this._service.OnStreamOnline += value;
+        remove => this._service.OnStreamOnline -= value;
+    }
+
+    public event EventHandler<OnStreamOfflineArgs>? OnStreamOffline
+    {
+        add => this._service.OnStreamOffline += value;
+        remove => this._service.OnStreamOffline -= value;
+    }
+
+    public void SetChannelsByName(List<string> channelsToMonitor)
+    {
+        this._service.SetChannelsByName(channelsToMonitor);
+    }
+
+    public Task UpdateLiveStreamersAsync()
+    {
+        return this._service.UpdateLiveStreamersAsync();
+    }
+}

--- a/src/Credfeto.Notification.Bot.Twitch/Services/LiveStreamMonitorAdapter.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/LiveStreamMonitorAdapter.cs
@@ -15,6 +15,7 @@ public sealed class LiveStreamMonitorAdapter : ILiveStreamMonitor
 
     public LiveStreamMonitorAdapter(IOptions<TwitchBotOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(options);
         this._service = new(options.Value.ConfigureTwitchApi());
     }
 

--- a/src/Credfeto.Notification.Bot.Twitch/Services/TwitchStreamStatus.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/TwitchStreamStatus.cs
@@ -6,16 +6,12 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Date.Interfaces;
-using Credfeto.Notification.Bot.Twitch.Configuration;
 using Credfeto.Notification.Bot.Twitch.DataTypes;
-using Credfeto.Notification.Bot.Twitch.Extensions;
 using Credfeto.Notification.Bot.Twitch.Models;
 using Credfeto.Notification.Bot.Twitch.Services.LoggingExtensions;
 using Mediator;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using NonBlocking;
-using TwitchLib.Api.Services;
 using TwitchLib.Api.Services.Events.LiveStreamMonitor;
 
 namespace Credfeto.Notification.Bot.Twitch.Services;
@@ -28,15 +24,20 @@ public sealed class TwitchStreamStatus : ITwitchStreamStatus, IDisposable
 
     private readonly SemaphoreSlim _lock;
     private readonly ILogger<TwitchStreamStatus> _logger;
-    private readonly LiveStreamMonitorService _lsm;
+    private readonly ILiveStreamMonitor _lsm;
     private readonly IMediator _mediator;
     private readonly IDisposable _offlineSubscription;
     private readonly IDisposable _onlineSubscription;
     private int _lastVersion;
     private int _version;
 
-    public TwitchStreamStatus(IOptions<TwitchBotOptions> options, IMediator mediator, ILogger<TwitchStreamStatus> logger)
+    public TwitchStreamStatus(
+        ILiveStreamMonitor liveStreamMonitor,
+        IMediator mediator,
+        ILogger<TwitchStreamStatus> logger
+    )
     {
+        this._lsm = liveStreamMonitor ?? throw new ArgumentNullException(nameof(liveStreamMonitor));
         this._mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -44,8 +45,6 @@ public sealed class TwitchStreamStatus : ITwitchStreamStatus, IDisposable
         this._lastVersion = 0;
         this._channels = new();
         this._lock = new(1);
-
-        this._lsm = new(options.Value.ConfigureTwitchApi());
 
         this._onlineSubscription = this.SubscribeToStreamOnlineNotifications();
 
@@ -92,6 +91,7 @@ public sealed class TwitchStreamStatus : ITwitchStreamStatus, IDisposable
             this._logger.StreamertNotFound(streamer: streamer, message: exception.Message, exception: exception);
 
             this._channels.TryRemove(key: streamer, value: out _);
+            Interlocked.Increment(location: ref this._version);
         }
         finally
         {
@@ -109,39 +109,79 @@ public sealed class TwitchStreamStatus : ITwitchStreamStatus, IDisposable
         }
     }
 
-    [SuppressMessage(category: "Meziantou.Analyzer", checkId: "MA0032: Use CancellationToken", Justification = "Using IDisposable instead")]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0032: Use CancellationToken",
+        Justification = "Using IDisposable instead"
+    )]
     private IDisposable SubscribeToStreamOfflineNotifications()
     {
-        return Observable.FromEventPattern<OnStreamOfflineArgs>(addHandler: h => this._lsm.OnStreamOffline += h, removeHandler: h => this._lsm.OnStreamOffline -= h)
-                         .Select(messageEvent => messageEvent.EventArgs)
-                         .Select(e => Observable.FromAsync(cancellationToken => this.OnStreamOfflineAsync(e: e, cancellationToken: cancellationToken)))
-                         .Concat()
-                         .Subscribe();
+        return Observable
+            .FromEventPattern<OnStreamOfflineArgs>(
+                addHandler: h => this._lsm.OnStreamOffline += h,
+                removeHandler: h => this._lsm.OnStreamOffline -= h
+            )
+            .Select(messageEvent => messageEvent.EventArgs)
+            .Select(e =>
+                Observable.FromAsync(cancellationToken =>
+                    this.OnStreamOfflineAsync(e: e, cancellationToken: cancellationToken)
+                )
+            )
+            .Concat()
+            .Subscribe();
     }
 
-    [SuppressMessage(category: "Meziantou.Analyzer", checkId: "MA0032: Use CancellationToken", Justification = "Using IDisposable instead")]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0032: Use CancellationToken",
+        Justification = "Using IDisposable instead"
+    )]
     private IDisposable SubscribeToStreamOnlineNotifications()
     {
-        return Observable.FromEventPattern<OnStreamOnlineArgs>(addHandler: h => this._lsm.OnStreamOnline += h, removeHandler: h => this._lsm.OnStreamOnline -= h)
-                         .Select(messageEvent => messageEvent.EventArgs)
-                         .Select(e => Observable.FromAsync(cancellationToken => this.OnStreamOnlineAsync(e: e, cancellationToken: cancellationToken)))
-                         .Concat()
-                         .Subscribe();
+        return Observable
+            .FromEventPattern<OnStreamOnlineArgs>(
+                addHandler: h => this._lsm.OnStreamOnline += h,
+                removeHandler: h => this._lsm.OnStreamOnline -= h
+            )
+            .Select(messageEvent => messageEvent.EventArgs)
+            .Select(e =>
+                Observable.FromAsync(cancellationToken =>
+                    this.OnStreamOnlineAsync(e: e, cancellationToken: cancellationToken)
+                )
+            )
+            .Concat()
+            .Subscribe();
     }
 
     private async Task OnStreamOnlineAsync(OnStreamOnlineArgs e, CancellationToken cancellationToken)
     {
         Streamer streamer = Streamer.FromString(e.Channel);
-        this._logger.StreamStarted(streamer: streamer, title: e.Stream.Title, gameName: e.Stream.GameName, e.Stream.StartedAt.AsDateTimeOffset());
+        this._logger.StreamStarted(
+            streamer: streamer,
+            title: e.Stream.Title,
+            gameName: e.Stream.GameName,
+            e.Stream.StartedAt.AsDateTimeOffset()
+        );
 
         try
         {
-            await this._mediator.Publish(new TwitchStreamOnline(streamer: streamer, title: e.Stream.Title, gameName: e.Stream.GameName, startedAt: e.Stream.StartedAt),
-                                         cancellationToken: cancellationToken);
+            await this._mediator.Publish(
+                new TwitchStreamOnline(
+                    streamer: streamer,
+                    title: e.Stream.Title,
+                    gameName: e.Stream.GameName,
+                    startedAt: e.Stream.StartedAt
+                ),
+                cancellationToken: cancellationToken
+            );
         }
         catch (Exception exception)
         {
-            this._logger.FailedToNotifyStreamStarted(streamer: streamer, message: exception.Message, exception: exception);
+            this._logger.FailedToNotifyStreamStarted(
+                streamer: streamer,
+                message: exception.Message,
+                exception: exception
+            );
         }
     }
 
@@ -151,12 +191,23 @@ public sealed class TwitchStreamStatus : ITwitchStreamStatus, IDisposable
 
         try
         {
-            await this._mediator.Publish(new TwitchStreamOffline(streamer: streamer, title: e.Stream.Title, gameName: e.Stream.GameName, startedAt: e.Stream.StartedAt),
-                                         cancellationToken: cancellationToken);
+            await this._mediator.Publish(
+                new TwitchStreamOffline(
+                    streamer: streamer,
+                    title: e.Stream.Title,
+                    gameName: e.Stream.GameName,
+                    startedAt: e.Stream.StartedAt
+                ),
+                cancellationToken: cancellationToken
+            );
         }
         catch (Exception exception)
         {
-            this._logger.FailedToNotifyStreamStopped(streamer: streamer, message: exception.Message, exception: exception);
+            this._logger.FailedToNotifyStreamStopped(
+                streamer: streamer,
+                message: exception.Message,
+                exception: exception
+            );
         }
     }
 }

--- a/src/Credfeto.Notification.Bot.Twitch/TwitchSetup.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/TwitchSetup.cs
@@ -49,6 +49,7 @@ public static class TwitchSetup
             .AddSingleton<ITwitchChat, TwitchChat>()
             .AddSingleton<ITwitchCustomMessageHandler, TwitchCustomMessageHandler>()
             .AddSingleton<ITwitchMessageTriggerDebounceFilter, TwitchMessageTriggerDebounceFilter>()
+            .AddSingleton<ILiveStreamMonitor, LiveStreamMonitorAdapter>()
             .AddSingleton<ITwitchStreamStatus, TwitchStreamStatus>()
             .AddSingleton<ITwitchStreamStateManager, TwitchStreamStateManager>()
             .AddSingleton<IUserInfoService, UserInfoService>();


### PR DESCRIPTION
## Summary

- Fixes a bug where `TwitchStreamStatus.UpdateAsync` removes an unknown streamer from `_channels` but never increments `_version`, so `LiveStreamMonitorService` keeps its stale channel list and throws the same `InvalidOperationException` on every subsequent poll — permanently breaking online/offline detection for all watched channels.
- Adds `Interlocked.Increment(ref _version)` in the catch block after `TryRemove` so the version guard triggers `SetChannelsByName` on the next poll.
- Extracts a minimal `ILiveStreamMonitor` interface and a thin `LiveStreamMonitorAdapter` wrapper so `TwitchStreamStatus` can be unit-tested with a mock.
- Adds a new test `UpdateAsyncShouldRefreshChannelListAfterUnknownStreamerIsRemoved` that verifies the channel list is refreshed after an unknown streamer is pruned.

## Test plan

- [ ] `dotnet build` passes with no errors or warnings.
- [ ] Existing tests pass: `dotnet test`.
- [ ] New test `UpdateAsyncShouldRefreshChannelListAfterUnknownStreamerIsRemoved` passes, verifying that a second `UpdateAsync` call triggers `SetChannelsByName` with the pruned list after the first call prunes an unknown streamer.
- [ ] `DependencyInjectionTests` still resolve `ITwitchStreamStatus` successfully with the updated DI wiring.

Closes #252