### PR TITLE
fix: RestoreTwitchChatConnectionWorker swallows exceptions instead of rethrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 - Increment version after removing unknown Twitch streamer so the next poll refreshes the channel list
+- RestoreTwitchChatConnectionWorker now logs and swallows exceptions rather than rethrowing them, preventing a transient ITwitchChat.UpdateAsync failure from crashing the host or permanently disabling chat reconnection
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Notification.Bot.Twitch.Tests/BackgroundServices/RestoreTwitchChatConnectionWorkerTests.cs
+++ b/src/Credfeto.Notification.Bot.Twitch.Tests/BackgroundServices/RestoreTwitchChatConnectionWorkerTests.cs
@@ -39,7 +39,7 @@ public sealed class RestoreTwitchChatConnectionWorkerTests : LoggingTestBase
     }
 
     [Fact]
-    public async Task ExceptionInUpdateAsyncShouldPropagate()
+    public async Task ExceptionInUpdateAsyncShouldBeSwallowed()
     {
         using System.Threading.CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(200));
 

--- a/src/Credfeto.Notification.Bot.Twitch/BackgroundServices/RestoreTwitchChatConnectionWorker.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/BackgroundServices/RestoreTwitchChatConnectionWorker.cs
@@ -38,8 +38,6 @@ public sealed class RestoreTwitchChatConnectionWorker : BackgroundService
         catch (Exception exception)
         {
             this._logger.FailedToUpdateTwitchChatConnection(message: exception.Message, exception: exception);
-
-            throw;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Remove `throw;` from `RestoreTwitchChatConnectionWorker.UpdateStatusAsync` so a transient `ITwitchChat.UpdateAsync` failure is logged and the worker continues on the next 30-second tick rather than crashing the host or permanently disabling chat reconnection.
- Rename the existing test `ExceptionInUpdateAsyncShouldPropagate` → `ExceptionInUpdateAsyncShouldBeSwallowed` to accurately reflect the corrected behaviour, matching the sibling `UpdateTwitchLiveStatusWorkerTests`.

## Test plan

- [ ] All 104 existing tests in `Credfeto.Notification.Bot.Twitch.Tests` pass (verified locally via `dotnet run --project`).
- [ ] Full solution builds with 0 warnings and 0 errors.
- [ ] CI passes.

Closes #253