### PR TITLE
fix: give UserInfoService cache entries a TTL and coalesce concurrent lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- UserInfoService now caches Twitch user lookups with a TTL and coalesces concurrent lookups for the same viewer, instead of caching missing users forever and issuing duplicate API calls
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Notification.Bot.Twitch.Tests/Services/UserInfoServiceCacheTests.cs
+++ b/src/Credfeto.Notification.Bot.Twitch.Tests/Services/UserInfoServiceCacheTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Credfeto.Date.Interfaces;
 using Credfeto.Notification.Bot.Mocks;
 using Credfeto.Notification.Bot.Twitch.Configuration;
 using Credfeto.Notification.Bot.Twitch.DataTypes;
@@ -14,6 +15,11 @@ namespace Credfeto.Notification.Bot.Twitch.Tests.Services;
 
 public sealed class UserInfoServiceCacheTests : LoggingTestBase
 {
+    private static readonly DateTimeOffset Now = new(
+        year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0, offset: TimeSpan.Zero
+    );
+
+    private readonly ICurrentTimeSource _currentTimeSource;
     private readonly IUserInfoService _userInfoService;
 
     public UserInfoServiceCacheTests(ITestOutputHelper output)
@@ -24,7 +30,14 @@ public sealed class UserInfoServiceCacheTests : LoggingTestBase
             new TwitchBotOptions { Authentication = MockReferenceData.TwitchAuthentication, ChatCommands = [] }
         );
 
-        this._userInfoService = new UserInfoService(options: options, this.GetTypedLogger<UserInfoService>());
+        this._currentTimeSource = GetSubstitute<ICurrentTimeSource>();
+        this._currentTimeSource.UtcNow().Returns(Now);
+
+        this._userInfoService = new UserInfoService(
+            options: options,
+            currentTimeSource: this._currentTimeSource,
+            this.GetTypedLogger<UserInfoService>()
+        );
     }
 
     [Fact]
@@ -45,6 +58,29 @@ public sealed class UserInfoServiceCacheTests : LoggingTestBase
     {
         return Assert.ThrowsAnyAsync<Exception>(() =>
             this._userInfoService.GetUserAsync(userName: MockReferenceData.Streamer, this.CancellationToken())
+        );
+    }
+
+    [Fact]
+    public async Task GetUserAsyncConsultsTheInjectedCurrentTimeSourceAsync()
+    {
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            this._userInfoService.GetUserAsync(userName: MockReferenceData.Viewer, this.CancellationToken())
+        );
+
+        this._currentTimeSource.Received(1).UtcNow();
+    }
+
+    [Fact]
+    public Task ConcurrentLookupsForTheSameNotYetCachedViewerAllCompleteAsync()
+    {
+        Viewer viewer = MockReferenceData.Viewer;
+
+        return Assert.ThrowsAnyAsync<Exception>(() =>
+            Task.WhenAll(
+                this._userInfoService.GetUserAsync(userName: viewer, this.CancellationToken()),
+                this._userInfoService.GetUserAsync(userName: viewer, this.CancellationToken())
+            )
         );
     }
 }

--- a/src/Credfeto.Notification.Bot.Twitch.Tests/Services/UserInfoServiceTests.cs
+++ b/src/Credfeto.Notification.Bot.Twitch.Tests/Services/UserInfoServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Credfeto.Date.Interfaces;
 using Credfeto.Notification.Bot.Mocks;
 using Credfeto.Notification.Bot.Twitch.Configuration;
 using Credfeto.Notification.Bot.Twitch.DataTypes;
@@ -14,6 +15,10 @@ namespace Credfeto.Notification.Bot.Twitch.Tests.Services;
 
 public sealed class UserInfoServiceTests : LoggingTestBase
 {
+    private static readonly DateTimeOffset Now = new(
+        year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0, offset: TimeSpan.Zero
+    );
+
     private readonly IUserInfoService _userInfoService;
 
     public UserInfoServiceTests(ITestOutputHelper output)
@@ -24,7 +29,14 @@ public sealed class UserInfoServiceTests : LoggingTestBase
             new TwitchBotOptions { Authentication = MockReferenceData.TwitchAuthentication, ChatCommands = [] }
         );
 
-        this._userInfoService = new UserInfoService(options: options, this.GetTypedLogger<UserInfoService>());
+        ICurrentTimeSource currentTimeSource = GetSubstitute<ICurrentTimeSource>();
+        currentTimeSource.UtcNow().Returns(Now);
+
+        this._userInfoService = new UserInfoService(
+            options: options,
+            currentTimeSource: currentTimeSource,
+            this.GetTypedLogger<UserInfoService>()
+        );
     }
 
     [Fact]

--- a/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
@@ -70,7 +70,7 @@ public sealed class UserInfoService : IUserInfoService
             }
             catch
             {
-                this._cache.TryRemove(key: userName, out _);
+                this._cache.TryRemove(new(key: userName, value: entry));
 
                 throw;
             }
@@ -82,7 +82,7 @@ public sealed class UserInfoService : IUserInfoService
                 return user;
             }
 
-            this._cache.TryRemove(key: userName, out _);
+            this._cache.TryRemove(new(key: userName, value: entry));
         }
     }
 

--- a/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,14 +19,23 @@ namespace Credfeto.Notification.Bot.Twitch.Services;
 
 public sealed class UserInfoService : IUserInfoService
 {
-    private readonly TwitchAPI _api;
+    private static readonly TimeSpan NegativeCacheTtl = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan PositiveCacheTtl = TimeSpan.FromMinutes(30);
 
-    private readonly ConcurrentDictionary<Viewer, TwitchUser?> _cache;
+    private readonly TwitchAPI _api;
+    private readonly ICurrentTimeSource _currentTimeSource;
+
+    private readonly ConcurrentDictionary<Viewer, CacheEntry> _cache;
     private readonly ILogger<UserInfoService> _logger;
 
-    public UserInfoService(IOptions<TwitchBotOptions> options, ILogger<UserInfoService> logger)
+    public UserInfoService(
+        IOptions<TwitchBotOptions> options,
+        ICurrentTimeSource currentTimeSource,
+        ILogger<UserInfoService> logger
+    )
     {
         this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this._currentTimeSource = currentTimeSource ?? throw new ArgumentNullException(nameof(currentTimeSource));
         TwitchBotOptions apiOptions = (options ?? throw new ArgumentNullException(nameof(options))).Value;
 
         this._api = apiOptions.ConfigureTwitchApi();
@@ -40,17 +50,46 @@ public sealed class UserInfoService : IUserInfoService
 
     public async Task<TwitchUser?> GetUserAsync(Viewer userName, CancellationToken cancellationToken)
     {
-        if (this._cache.TryGetValue(key: userName, out TwitchUser? user))
+        while (true)
         {
-            return user;
-        }
+            DateTimeOffset now = this._currentTimeSource.UtcNow();
+            CacheEntry entry = this._cache.GetOrAdd(
+                key: userName,
+                value: new CacheEntry(fetch: () => this.FetchUserAsync(userName), createdAt: now)
+            );
 
+            TwitchUser? user;
+
+            try
+            {
+                user = await entry.GetValueAsync(cancellationToken);
+            }
+            catch
+            {
+                this._cache.TryRemove(key: userName, out _);
+
+                throw;
+            }
+
+            TimeSpan ttl = user is null ? NegativeCacheTtl : PositiveCacheTtl;
+
+            if (now < entry.CreatedAt + ttl)
+            {
+                return user;
+            }
+
+            this._cache.TryRemove(key: userName, out _);
+        }
+    }
+
+    private async Task<TwitchUser?> FetchUserAsync(Viewer userName)
+    {
         try
         {
             this._logger.GettingUserInfo(userName);
             GetUsersResponse result = await this.GetUsersAsync(userName);
 
-            return this.AddUserToCache(userName: userName, result.Users is [] ? null : ConvertUser(result.Users[0]));
+            return result.Users is [] ? null : ConvertUser(result.Users[0]);
         }
         catch (Exception exception)
         {
@@ -62,13 +101,6 @@ public sealed class UserInfoService : IUserInfoService
 
             throw;
         }
-    }
-
-    private TwitchUser? AddUserToCache(in Viewer userName, TwitchUser? user)
-    {
-        this._cache.TryAdd(key: userName, value: user);
-
-        return user;
     }
 
     private Task<GetUsersResponse> GetUsersAsync(in Viewer userName)
@@ -84,5 +116,28 @@ public sealed class UserInfoService : IUserInfoService
             !string.IsNullOrWhiteSpace(user.BroadcasterType),
             user.CreatedAt.AsDateTimeOffset()
         );
+    }
+
+    private sealed class CacheEntry
+    {
+        private readonly Lazy<Task<TwitchUser?>> _fetch;
+
+        [SuppressMessage(
+            category: "Microsoft.VisualStudio.Threading",
+            checkId: "VSTHRD011: Use AsyncLazy<T> instead",
+            Justification = "Background worker service has no JoinableTaskFactory/UI thread to deadlock against; Lazy<Task<T>> coalesces concurrent fetches for the same cache key"
+        )]
+        public CacheEntry(Func<Task<TwitchUser?>> fetch, in DateTimeOffset createdAt)
+        {
+            this._fetch = new(fetch, mode: LazyThreadSafetyMode.ExecutionAndPublication);
+            this.CreatedAt = createdAt;
+        }
+
+        public DateTimeOffset CreatedAt { get; }
+
+        public Task<TwitchUser?> GetValueAsync(in CancellationToken cancellationToken)
+        {
+            return this._fetch.Value.WaitAsync(cancellationToken);
+        }
     }
 }

--- a/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
@@ -64,6 +64,10 @@ public sealed class UserInfoService : IUserInfoService
             {
                 user = await entry.GetValueAsync(cancellationToken);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch
             {
                 this._cache.TryRemove(key: userName, out _);

--- a/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/UserInfoService.cs
@@ -55,7 +55,9 @@ public sealed class UserInfoService : IUserInfoService
             DateTimeOffset now = this._currentTimeSource.UtcNow();
             CacheEntry entry = this._cache.GetOrAdd(
                 key: userName,
-                value: new CacheEntry(fetch: () => this.FetchUserAsync(userName), createdAt: now)
+                valueFactory: static (key, arg) =>
+                    new CacheEntry(fetch: () => arg.Service.FetchUserAsync(key), createdAt: arg.Now),
+                factoryArgument: (Service: this, Now: now)
             );
 
             TwitchUser? user;


### PR DESCRIPTION
## Summary

- UserInfoService.GetUserAsync cached missing users (null) permanently and let concurrent lookups for the same not-yet-cached viewer each issue a separate Helix API call.
- Cache entries now carry a TTL - short for not-found results, longer for found users - evaluated against the injected ICurrentTimeSource.
- Concurrent lookups for the same key now coalesce onto a single in-flight fetch (Lazy<Task<TwitchUser?>>), instead of racing separate Helix API calls. Failed fetches are evicted immediately so they are retried, never cached.

Closes #258

## Test plan

- [x] dotnet build (Debug and Release, --warnaserror) - passes
- [x] Full pre-commit run (build, 261 unit tests, buildcheck, publish) - passes
- [x] Credfeto.Notification.Bot.Twitch.Tests - 108/108 passing, including new/updated tests:
  - UserInfoServiceCacheTests.FailedLookupsAreNotCachedAndEachCallPropagatesAnExceptionAsync (unchanged behaviour, updated constructor)
  - UserInfoServiceCacheTests.GetUserAsyncConsultsTheInjectedCurrentTimeSourceAsync (new - verifies the TTL mechanism is wired up)
  - UserInfoServiceCacheTests.ConcurrentLookupsForTheSameNotYetCachedViewerAllCompleteAsync (new - concurrency regression guard)