### PR TITLE
fix: snapshot version in TwitchStreamStatus to close a channel-registration race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -11,6 +14,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Fixed
 - UserInfoService now caches Twitch user lookups with a TTL and coalesces concurrent lookups for the same viewer, instead of caching missing users forever and issuing duplicate API calls
 ### Changed
+### Deprecated
 ### Removed
 ### Deployment Changes
 <!--

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 - UserInfoService now caches Twitch user lookups with a TTL and coalesces concurrent lookups for the same viewer, instead of caching missing users forever and issuing duplicate API calls
+- Fixed a race in TwitchStreamStatus version tracking that could leave a newly-enabled Twitch channel permanently unmonitored.
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Credfeto.Notification.Bot.Twitch.Tests/Services/TwitchStreamStatusTests.cs
+++ b/src/Credfeto.Notification.Bot.Twitch.Tests/Services/TwitchStreamStatusTests.cs
@@ -68,4 +68,30 @@ public sealed class TwitchStreamStatusTests : LoggingTestBase
         this._liveStreamMonitor.Received(1)
             .SetChannelsByName(Arg.Is<List<string>>(l => l.Count == 1 && l.Contains(streamer2.Value)));
     }
+
+    [Fact]
+    public async Task UpdateAsyncShouldNotLoseVersionBumpFromConcurrentEnableAsync()
+    {
+        Streamer streamer1 = Streamer.FromString("teststreamer1");
+        Streamer streamer2 = Streamer.FromString("teststreamer2");
+
+        Task? reentrantEnableTask = null;
+
+        this._liveStreamMonitor.When(x => x.SetChannelsByName(Arg.Any<List<string>>()))
+            .Do(_ => reentrantEnableTask ??= this._twitchStreamStatus.EnableAsync(streamer2).AsTask());
+
+        await this._twitchStreamStatus.EnableAsync(streamer1);
+
+        Assert.NotNull(reentrantEnableTask);
+
+        await reentrantEnableTask;
+
+        this._liveStreamMonitor.Received(1)
+            .SetChannelsByName(Arg.Is<List<string>>(l => l.Count == 1 && l.Contains(streamer1.Value)));
+
+        this._liveStreamMonitor.Received(1)
+            .SetChannelsByName(
+                Arg.Is<List<string>>(l => l.Count == 2 && l.Contains(streamer1.Value) && l.Contains(streamer2.Value))
+            );
+    }
 }

--- a/src/Credfeto.Notification.Bot.Twitch/Services/TwitchStreamStatus.cs
+++ b/src/Credfeto.Notification.Bot.Twitch/Services/TwitchStreamStatus.cs
@@ -69,10 +69,12 @@ public sealed class TwitchStreamStatus : ITwitchStreamStatus, IDisposable
 
         try
         {
-            if (this._lastVersion != this._version)
+            int version = this._version;
+
+            if (this._lastVersion != version)
             {
                 this._lsm.SetChannelsByName([.. this._channels.Keys.Select(c => c.Value)]);
-                this._lastVersion = this._version;
+                this._lastVersion = version;
             }
 
             await this._lsm.UpdateLiveStreamersAsync();


### PR DESCRIPTION
## Summary

Placeholder PR for issue #254. Implementation follows in a subsequent cycle per the approved plan.

`TwitchStreamStatus.UpdateAsync` currently re-reads the mutable `_version` field after calling `SetChannelsByName`, instead of using a single snapshot taken before the call. If `EnableAsync` increments `_version` (outside the lock) between the `SetChannelsByName` call and the `_lastVersion` assignment, that version bump is recorded as already-synced even though the new channel was never passed to `SetChannelsByName`. The affected streamer then never receives online/offline notifications until another channel happens to be enabled.

The approved plan (see issue comment) snapshots `this._version` into a local variable once, before calling `SetChannelsByName`, and assigns `_lastVersion` from that snapshot rather than re-reading the live field afterwards, so a concurrent increment is left pending for the next poll instead of being silently dropped.

## Test plan

- [ ] Add a regression test to `TwitchStreamStatusTests` that deterministically reproduces the race (a second `EnableAsync` call triggered from within the `SetChannelsByName` mock side effect) and asserts the version bump is not lost.
- [ ] `dotnet build` and `dotnet test` pass.

Closes #254