### PR TITLE
fix: use ConcurrentDictionary for TwitchInputMessageMatch regex cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - UserInfoService now caches Twitch user lookups with a TTL and coalesces concurrent lookups for the same viewer, instead of caching missing users forever and issuing duplicate API calls
 - Fixed a race in TwitchStreamStatus version tracking that could leave a newly-enabled Twitch channel permanently unmonitored.
 - Jitter calculation no longer allocates and disposes a cryptographic RandomNumberGenerator per outgoing chat message
+- Fixed potential thread-safety hazard in TwitchInputMessageMatch's regex cache by switching to a concurrent dictionary
 ### Changed
 ### Deprecated
 ### Removed

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -1,0 +1,26 @@
+# Code Coverage Baseline
+
+This file tracks the coverage ratchet baseline. Future PRs must keep each language's
+`Overall` figure at or above the value recorded here; it is updated after each PR
+whose AI Coverage phase passes.
+
+Method: pooled `lines-covered` / `lines-valid` (cobertura) summed across all
+`*.Tests` unit-test projects (integration and benchmark test projects excluded),
+one `dotnet test ... --coverage --coverage-output-format cobertura` run per
+project. `dotnet reportgenerator` was unavailable in the environment this
+baseline was measured in, so the cobertura XML totals were read directly rather
+than via a generated report; `coverage-ratchet.instructions.md` (referenced by
+the orchestrator's AI Coverage phase) does not exist in this repo's `ai/`
+tree — this baseline and method were established ad hoc pending that file
+being added.
+
+## .NET
+
+| Component | Coverage |
+| --- | --- |
+| Credfeto.Notification.Bot.Server | 41.30% |
+| Credfeto.Notification.Bot.Shared | 100.00% |
+| Credfeto.Notification.Bot.Twitch.DataTypes | 100.00% |
+| Credfeto.Notification.Bot.Twitch.Models | 100.00% |
+| Credfeto.Notification.Bot.Twitch | 78.71% |
+| **Overall** | **77.43%** |

--- a/src/Credfeto.Notification.Bot.Twitch.Models/Credfeto.Notification.Bot.Twitch.Models.csproj
+++ b/src/Credfeto.Notification.Bot.Twitch.Models/Credfeto.Notification.Bot.Twitch.Models.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+    <PackageReference Include="NonBlocking" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" ExcludeAssets="runtime" />

--- a/src/Credfeto.Notification.Bot.Twitch.Models/TwitchInputMessageMatch.cs
+++ b/src/Credfeto.Notification.Bot.Twitch.Models/TwitchInputMessageMatch.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Credfeto.Notification.Bot.Twitch.DataTypes;
+using NonBlocking;
 
 namespace Credfeto.Notification.Bot.Twitch.Models;
 
@@ -19,7 +19,7 @@ public sealed class TwitchInputMessageMatch : IEquatable<TwitchInputMessageMatch
 
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(5);
 
-    private static readonly Dictionary<string, Regex> RegexCache = new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, Regex> RegexCache = new(StringComparer.Ordinal);
 
     public TwitchInputMessageMatch(
         in Streamer streamer,
@@ -67,15 +67,12 @@ public sealed class TwitchInputMessageMatch : IEquatable<TwitchInputMessageMatch
     {
         if (matchType == TwitchMessageMatchType.REGEX)
         {
-            if (RegexCache.TryGetValue(key: expression, out Regex? regex))
-            {
-                return regex;
-            }
-
-            regex = new(pattern: expression, options: REGEX_OPTIONS, matchTimeout: RegexTimeout);
-            RegexCache.Add(key: expression, value: regex);
-
-            return regex;
+            return RegexCache.GetOrAdd(
+                key: expression,
+                valueFactory: static (expr, timeout) =>
+                    new(pattern: expr, options: REGEX_OPTIONS, matchTimeout: timeout),
+                factoryArgument: RegexTimeout
+            );
         }
 
         return null;


### PR DESCRIPTION
## Summary

`TwitchInputMessageMatch` cached compiled regexes in a plain `Dictionary<string, Regex>` that was read and written (`TryGetValue` + `Add`) from the constructor with no locking. This is a latent thread-safety hazard: any concurrent construction (parallel DI resolution, tests, new call sites) could corrupt the dictionary or throw on a duplicate key `Add`.

This replaces the plain `Dictionary` with `NonBlocking.ConcurrentDictionary<string, Regex>` and uses `GetOrAdd` (the 3-argument factory overload with an explicit `factoryArgument`, required by `FunFair.CodeAnalysis` FFS0033 which bans the 2-argument `Func<TKey, TValue>` overload) instead of the racy `TryGetValue`/`Add` check-then-act pattern. This also removes the duplicate-key race, with no change to the public API or behaviour for callers.

Closes #256

## Test plan

- [x] Existing test `Constructor_WithRegexMatchType_SecondCallWithSameExpression_ReturnsCachedRegex` continues to cover the caching contract (two constructions with the same pattern return the same cached `Regex` instance).
- [x] `dotnet build` succeeds with 0 warnings/errors.
- [x] `dotnet test` for `Credfeto.Notification.Bot.Twitch.Models.Tests`: 72/72 passed, 100% line/branch coverage on `TwitchInputMessageMatch`.
- [x] Full solution `pre-commit --all-files` (build, all 262 tests, publish) passes.
- [x] `dotnet buildcheck` passes with no errors.