### PR TITLE
fix: raise .globalconfig analyzer severities (FFS0040, FFS0042, MA0026, S125) to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Fixed a race in TwitchStreamStatus version tracking that could leave a newly-enabled Twitch channel permanently unmonitored.
 - Jitter calculation no longer allocates and disposes a cryptographic RandomNumberGenerator per outgoing chat message
 - Fixed potential thread-safety hazard in TwitchInputMessageMatch's regex cache by switching to a concurrent dictionary
+- Raise .globalconfig analyzer severities from suggestion to error (FFS0040, FFS0042, MA0026, S125) and fix violations surfaced by dotnet buildcheck
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
## Summary
- Regenerate `.globalconfig` via `dotnet buildcheck` and raise FFS0040, FFS0042, MA0026 and S125 from suggestion to error, then fix every violation this surfaces across the solution.
- Investigate and fix the 4 pre-existing IDE0022/IDE1006 errors seen on a plain Release build (per issue discussion, all build errors are in scope for this change).

## Test plan
- [ ] `dotnet buildcheck` regenerates `.globalconfig` with no further diff
- [ ] `dotnet build src/Credfeto.Notification.Bot.slnx -c Release --no-incremental` completes with zero errors
- [ ] All existing xunit test projects pass via `dotnet test`
- [ ] Pre-commit hook's buildcheck step runs clean with no `.globalconfig` diff

Closes #272